### PR TITLE
fix(image_gen): 自动识别生图响应格式并修复 WebUI request_params 搜索 (v3.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v3.6.8 生图响应自动识别与 WebUI request_params 搜索修复
+
+本版本修复 OpenAI 兼容生图链路对 `response_format` 的错误默认与解析依赖，并加固 base64 解码；同时修正 WebUI 配置搜索会把 `request_params` 结构化编辑器里的 key/type 控件单独隐藏的问题。
+
+- 生图响应按 payload **自动识别**格式：`http(s) url` / data URL / `url` 内原始 base64 / `b64_json` / `base64`，不再依赖请求或配置中的 `response_format` 做解析分支。
+- 停止默认写入 `response_format=base64`：仅当工具参数显式传入时覆盖；否则保留 `request_params` 中的值（若有），避免上游网关因默认格式不兼容而失败。
+- 加固 base64 解码：`validate=True` 校验字母表，并用 PNG/JPEG/GIF/BMP/WEBP 魔数确认结果为图片，拒绝把错误文本当成功生图。
+- 修复 WebUI 配置搜索：索引与过滤仅针对带 `data-path` 的表单项，嵌套 key/type 表单组不再被单独隐藏；`request_params` 编辑器占满网格宽度，搜索匹配时 key/type 仍可见。
+- 同步配置文档与回归测试：覆盖 payload 解析回落、edit-form 默认值、base64 校验，以及 config search 对 request_params 嵌套控件的可见性。
+
+---
+
 ## v3.6.7 Naga 会话级黑白名单
 
 本版本将 Naga 启用粒度从进程全局细化到群聊/私聊会话：在总闸打开后，可按 `mode` 名单控制具体群与私聊是否启用 NagaAgent 提示词、相关 Agent 与外部网关能力，并保证提示词与工具暴露/执行结论一致。

--- a/apps/undefined-chat/package-lock.json
+++ b/apps/undefined-chat/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "undefined-chat",
-	"version": "3.6.7",
+	"version": "3.6.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "undefined-chat",
-			"version": "3.6.7",
+			"version": "3.6.8",
 			"dependencies": {
 				"@tauri-apps/api": "^2.3.0",
 				"@tauri-apps/plugin-dialog": "^2.7.1",

--- a/apps/undefined-chat/package.json
+++ b/apps/undefined-chat/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "undefined-chat",
 	"private": true,
-	"version": "3.6.7",
+	"version": "3.6.8",
 	"type": "module",
 	"scripts": {
 		"tauri": "tauri",

--- a/apps/undefined-chat/src-tauri/Cargo.lock
+++ b/apps/undefined-chat/src-tauri/Cargo.lock
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "undefined_chat"
-version = "3.6.7"
+version = "3.6.8"
 dependencies = [
  "futures-util",
  "keyring",

--- a/apps/undefined-chat/src-tauri/Cargo.toml
+++ b/apps/undefined-chat/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undefined_chat"
-version = "3.6.7"
+version = "3.6.8"
 description = "Undefined native chat client"
 authors = ["Undefined contributors"]
 license = "MIT"

--- a/apps/undefined-chat/src-tauri/tauri.conf.json
+++ b/apps/undefined-chat/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Undefined Chat",
-	"version": "3.6.7",
+	"version": "3.6.8",
 	"identifier": "com.undefined.chat",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/apps/undefined-console/package-lock.json
+++ b/apps/undefined-console/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "undefined-console",
-	"version": "3.6.7",
+	"version": "3.6.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "undefined-console",
-			"version": "3.6.7",
+			"version": "3.6.8",
 			"dependencies": {
 				"@tauri-apps/api": "^2.3.0",
 				"@tauri-apps/plugin-http": "^2.3.0"

--- a/apps/undefined-console/package.json
+++ b/apps/undefined-console/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "undefined-console",
 	"private": true,
-	"version": "3.6.7",
+	"version": "3.6.8",
 	"type": "module",
 	"scripts": {
 		"tauri": "tauri",

--- a/apps/undefined-console/src-tauri/Cargo.lock
+++ b/apps/undefined-console/src-tauri/Cargo.lock
@@ -4063,7 +4063,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "undefined_console"
-version = "3.6.7"
+version = "3.6.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/undefined-console/src-tauri/Cargo.toml
+++ b/apps/undefined-console/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "undefined_console"
-version = "3.6.7"
+version = "3.6.8"
 description = "Undefined cross-platform management console"
 authors = ["Undefined contributors"]
 license = "MIT"

--- a/apps/undefined-console/src-tauri/tauri.conf.json
+++ b/apps/undefined-console/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Undefined Console",
-	"version": "3.6.7",
+	"version": "3.6.8",
 	"identifier": "com.undefined.console",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -492,7 +492,7 @@ Prompt caching 补充：
 - `[models.image_gen].use_proxy` 控制 OpenAI-compatible 生图请求。
 - `[models.image_edit].use_proxy` 控制参考图生图请求。
 - `[image_gen].use_proxy` 控制非模型 provider（如星之阁）及图片下载链路，三者互不继承。
-- 生图响应按 payload **自动识别** `url` / `b64_json` / `base64` / data URL，不依赖 `request_params.response_format` 或工具参数；后者只影响**请求**偏好。
+- 生图响应按 payload **自动识别** `http(s) url` / data URL / `url` 内原始 base64 / `b64_json` / `base64`，不依赖 `request_params.response_format` 或工具参数；后者只影响**请求**偏好。解码 base64 时会校验字母表与常见图片魔数，避免把错误文本当图片。
 
 `request_params` 说明：
 - 仅用于**请求体**字段，不包含 `api_key`、`base_url`、`timeout`、`extra_headers` 等 client 选项。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -492,6 +492,7 @@ Prompt caching 补充：
 - `[models.image_gen].use_proxy` 控制 OpenAI-compatible 生图请求。
 - `[models.image_edit].use_proxy` 控制参考图生图请求。
 - `[image_gen].use_proxy` 控制非模型 provider（如星之阁）及图片下载链路，三者互不继承。
+- 生图响应按 payload **自动识别** `url` / `b64_json` / `base64` / data URL，不依赖 `request_params.response_format` 或工具参数；后者只影响**请求**偏好。
 
 `request_params` 说明：
 - 仅用于**请求体**字段，不包含 `api_key`、`base_url`、`timeout`、`extra_headers` 等 client 选项。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Undefined-bot"
-version = "3.6.7"
+version = "3.6.8"
 description = "QQ bot platform with cognitive memory architecture and multi-agent Skills, via OneBot V11."
 readme = "README.md"
 authors = [

--- a/src/Undefined/__init__.py
+++ b/src/Undefined/__init__.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from .skills.registry import BaseRegistry as BaseRegistry
     from .skills.tools import ToolRegistry as ToolRegistry
 
-__version__: str = "3.6.7"
+__version__: str = "3.6.8"
 
 # symbol -> (module_path, attribute_name)；首次访问时才 importlib 加载
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {

--- a/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/config.json
+++ b/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/config.json
@@ -24,7 +24,7 @@
                 },
                 "response_format": {
                     "type": "string",
-                    "description": "图片响应格式（仅 models 模式生效）",
+                    "description": "请求偏好的图片响应格式（仅 models 模式生效，影响上游请求体；返回解析始终按 payload 自动识别 url / b64_json / data URL，不依赖此字段）",
                     "enum": ["url", "b64_json", "base64"]
                 },
                 "delivery": {

--- a/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/handler.py
+++ b/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/handler.py
@@ -92,8 +92,33 @@ def _extract_first_image_item(data: dict[str, Any]) -> dict[str, Any] | None:
     return image_item
 
 
+def _is_likely_image_bytes(image_bytes: bytes) -> bool:
+    """用魔数判断解码结果是否像常见图片，避免把任意 base64 垃圾当图。"""
+    if not image_bytes:
+        return False
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return True
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return True
+    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return True
+    if image_bytes.startswith(b"BM"):
+        return True
+    if (
+        len(image_bytes) >= 12
+        and image_bytes.startswith(b"RIFF")
+        and image_bytes[8:12] == b"WEBP"
+    ):
+        return True
+    return False
+
+
 def _decode_image_base64(text: str) -> bytes | None:
-    """解码纯 base64 或 ``data:image/...;base64,...`` 图片内容。"""
+    """解码纯 base64 或 ``data:image/...;base64,...`` 图片内容。
+
+    使用 ``validate=True`` 拒绝非字母表字符，并用魔数确认结果是图片，
+    避免错误/文本 payload 被当作成功生图。
+    """
     payload = text.strip()
     if not payload:
         return None
@@ -104,10 +129,22 @@ def _decode_image_base64(text: str) -> bytes | None:
             return None
         payload = encoded.strip()
 
+    # 部分网关会在长 base64 中插入空白；去掉后再严格解码
+    compact = "".join(payload.split())
+    if not compact:
+        return None
+    padding = (-len(compact)) % 4
+    if padding:
+        compact = f"{compact}{'=' * padding}"
+
     try:
-        return base64.b64decode(payload, validate=False)
+        decoded = base64.b64decode(compact, validate=True)
     except (binascii.Error, ValueError):
         return None
+
+    if not _is_likely_image_bytes(decoded):
+        return None
+    return decoded
 
 
 def _parse_image_url(data: dict[str, Any]) -> str | None:
@@ -130,7 +167,8 @@ def _parse_generated_image(data: dict[str, Any]) -> _GeneratedImagePayload | Non
     优先级：
     1. ``url`` 为 http(s) → 远程 URL
     2. ``url`` 为 data URL → 解码为字节
-    3. ``b64_json`` / ``base64``（可含 data URL 前缀）→ 解码为字节
+    3. ``url`` 为原始 base64（部分网关）→ 解码为字节
+    4. ``b64_json`` / ``base64``（可含 data URL 前缀）→ 解码为字节
     """
     image_item = _extract_first_image_item(data)
     if image_item is None:
@@ -153,6 +191,17 @@ def _parse_generated_image(data: dict[str, Any]) -> _GeneratedImagePayload | Non
                         detected_format="data_url",
                     )
                 logger.warning("图片 data URL 解码失败，继续尝试其它字段")
+            else:
+                # 非 http(s)/data URL：部分网关把原始 base64 塞进 url
+                image_bytes = _decode_image_base64(url_text)
+                if image_bytes is not None:
+                    return _GeneratedImagePayload(
+                        image_bytes=image_bytes,
+                        detected_format="url_base64",
+                    )
+                logger.warning(
+                    "url 字段既非可下载链接也非有效图片 base64，继续尝试其它字段"
+                )
 
     for key in ("b64_json", "base64"):
         raw_value = image_item.get(key)

--- a/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/handler.py
+++ b/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/handler.py
@@ -21,6 +21,7 @@ from typing import Any
 import httpx
 
 from Undefined.attachments import scope_from_context
+from Undefined.attachments.segments import is_data_url, is_http_url
 from Undefined.ai.parsing import extract_choices_content
 from Undefined.skills.http_client import request_with_retry
 from Undefined.skills.http_config import get_request_timeout, get_xingzhige_url
@@ -45,6 +46,7 @@ _IMAGE_GEN_MODERATION_PROMPT: str | None = None
 class _GeneratedImagePayload:
     image_url: str | None = None
     image_bytes: bytes | None = None
+    detected_format: str | None = None
 
 
 def _record_image_gen_usage(
@@ -79,23 +81,78 @@ def _iso_now() -> str:
     return datetime.now().isoformat()
 
 
-def _parse_image_url(data: dict[str, Any]) -> str | None:
-    """从 API 响应中提取图片 URL"""
-    try:
-        return str(data["data"][0]["url"])
-    except (KeyError, IndexError, TypeError):
-        return None
-
-
-def _parse_image_bytes(data: dict[str, Any]) -> bytes | None:
-    """从 API 响应中提取 Base64 图片内容。"""
+def _extract_first_image_item(data: dict[str, Any]) -> dict[str, Any] | None:
+    """从 OpenAI 形 ``{"data":[{...}]}`` 取出首个图片 item。"""
     try:
         image_item = data["data"][0]
     except (KeyError, IndexError, TypeError):
         return None
-
     if not isinstance(image_item, dict):
         return None
+    return image_item
+
+
+def _decode_image_base64(text: str) -> bytes | None:
+    """解码纯 base64 或 ``data:image/...;base64,...`` 图片内容。"""
+    payload = text.strip()
+    if not payload:
+        return None
+
+    if is_data_url(payload):
+        header, _, encoded = payload.partition(",")
+        if not encoded or ";base64" not in header.lower():
+            return None
+        payload = encoded.strip()
+
+    try:
+        return base64.b64decode(payload, validate=False)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _parse_image_url(data: dict[str, Any]) -> str | None:
+    """从 API 响应中提取可下载的 http(s) 图片 URL（星之阁等路径复用）。"""
+    image_item = _extract_first_image_item(data)
+    if image_item is None:
+        return None
+    raw_url = image_item.get("url")
+    if raw_url is None:
+        return None
+    text = str(raw_url).strip()
+    if not text or not is_http_url(text):
+        return None
+    return text
+
+
+def _parse_generated_image(data: dict[str, Any]) -> _GeneratedImagePayload | None:
+    """按响应 payload 自动检测图片格式，不依赖请求/配置中的 response_format。
+
+    优先级：
+    1. ``url`` 为 http(s) → 远程 URL
+    2. ``url`` 为 data URL → 解码为字节
+    3. ``b64_json`` / ``base64``（可含 data URL 前缀）→ 解码为字节
+    """
+    image_item = _extract_first_image_item(data)
+    if image_item is None:
+        return None
+
+    raw_url = image_item.get("url")
+    if raw_url is not None:
+        url_text = str(raw_url).strip()
+        if url_text:
+            if is_http_url(url_text):
+                return _GeneratedImagePayload(
+                    image_url=url_text,
+                    detected_format="url",
+                )
+            if is_data_url(url_text):
+                image_bytes = _decode_image_base64(url_text)
+                if image_bytes is not None:
+                    return _GeneratedImagePayload(
+                        image_bytes=image_bytes,
+                        detected_format="data_url",
+                    )
+                logger.warning("图片 data URL 解码失败，继续尝试其它字段")
 
     for key in ("b64_json", "base64"):
         raw_value = image_item.get(key)
@@ -104,22 +161,13 @@ def _parse_image_bytes(data: dict[str, Any]) -> bytes | None:
         text = str(raw_value).strip()
         if not text:
             continue
-        try:
-            return base64.b64decode(text)
-        except (binascii.Error, ValueError):
-            logger.error("图片 Base64 解码失败: key=%s", key)
-            return None
-    return None
-
-
-def _parse_generated_image(data: dict[str, Any]) -> _GeneratedImagePayload | None:
-    image_url = _parse_image_url(data)
-    if image_url:
-        return _GeneratedImagePayload(image_url=image_url)
-
-    image_bytes = _parse_image_bytes(data)
-    if image_bytes is not None:
-        return _GeneratedImagePayload(image_bytes=image_bytes)
+        image_bytes = _decode_image_base64(text)
+        if image_bytes is not None:
+            return _GeneratedImagePayload(
+                image_bytes=image_bytes,
+                detected_format=key,
+            )
+        logger.warning("图片 Base64 解码失败: key=%s", key)
 
     return None
 
@@ -271,10 +319,9 @@ def _build_openai_models_request_body(
         body["quality"] = quality
     if style:
         body["style"] = style
+    # 仅在工具参数显式传入时覆盖；否则保留 request_params 中的值（若有），不默认塞 response_format
     if response_format:
         body["response_format"] = response_format
-    else:
-        body.setdefault("response_format", "base64")
     return body
 
 
@@ -334,10 +381,9 @@ def _build_openai_models_edit_form(
         body["quality"] = quality
     if style:
         body["style"] = style
+    # 仅在工具参数显式传入时覆盖；否则保留 request_params 中的值（若有），不默认塞 response_format
     if response_format:
         body["response_format"] = response_format
-    else:
-        body.setdefault("response_format", "base64")
     return {key: _stringify_multipart_value(value) for key, value in body.items()}
 
 
@@ -508,7 +554,10 @@ async def _call_openai_models(
         logger.error(f"图片生成 API 返回 (未找到图片链接): {data}")
         return f"API 返回原文 (错误：未找到图片内容): {data}"
 
-    logger.info(f"图片生成 API 返回: {data}")
+    logger.info(
+        "图片生成 API 解析成功: detected_format=%s",
+        generated_image.detected_format or "unknown",
+    )
     if generated_image.image_url:
         logger.info(f"提取图片链接: {generated_image.image_url}")
     elif generated_image.image_bytes is not None:
@@ -639,7 +688,10 @@ async def _call_openai_models_edit(
         logger.error(f"参考图生图 API 返回 (未找到图片内容): {data}")
         return f"API 返回原文 (错误：未找到图片内容): {data}"
 
-    logger.info(f"参考图生图 API 返回: {data}")
+    logger.info(
+        "参考图生图 API 解析成功: detected_format=%s",
+        generated_image.detected_format or "unknown",
+    )
     if generated_image.image_url:
         logger.info(f"提取图片链接: {generated_image.image_url}")
     elif generated_image.image_bytes is not None:

--- a/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/handler.py
+++ b/src/Undefined/skills/agents/entertainment_agent/tools/ai_draw_one/handler.py
@@ -21,7 +21,6 @@ from typing import Any
 import httpx
 
 from Undefined.attachments import scope_from_context
-from Undefined.attachments.segments import is_data_url, is_http_url
 from Undefined.ai.parsing import extract_choices_content
 from Undefined.skills.http_client import request_with_retry
 from Undefined.skills.http_config import get_request_timeout, get_xingzhige_url
@@ -40,6 +39,16 @@ _ALLOWED_MODELS_IMAGE_SIZES = (
 _ALLOWED_IMAGE_RESPONSE_FORMATS = ("url", "b64_json", "base64")
 _MAX_REFERENCE_IMAGE_UIDS = 16
 _IMAGE_GEN_MODERATION_PROMPT: str | None = None
+
+
+def _is_http_url(value: str) -> bool:
+    """判断字符串是否为 HTTP(S) URL（技能内本地实现，避免跨包耦合）。"""
+    return value.startswith("http://") or value.startswith("https://")
+
+
+def _is_data_url(value: str) -> bool:
+    """判断字符串是否为 ``data:`` URL（技能内本地实现，避免跨包耦合）。"""
+    return value.startswith("data:")
 
 
 @dataclass
@@ -123,7 +132,7 @@ def _decode_image_base64(text: str) -> bytes | None:
     if not payload:
         return None
 
-    if is_data_url(payload):
+    if _is_data_url(payload):
         header, _, encoded = payload.partition(",")
         if not encoded or ";base64" not in header.lower():
             return None
@@ -156,7 +165,7 @@ def _parse_image_url(data: dict[str, Any]) -> str | None:
     if raw_url is None:
         return None
     text = str(raw_url).strip()
-    if not text or not is_http_url(text):
+    if not text or not _is_http_url(text):
         return None
     return text
 
@@ -178,12 +187,12 @@ def _parse_generated_image(data: dict[str, Any]) -> _GeneratedImagePayload | Non
     if raw_url is not None:
         url_text = str(raw_url).strip()
         if url_text:
-            if is_http_url(url_text):
+            if _is_http_url(url_text):
                 return _GeneratedImagePayload(
                     image_url=url_text,
                     detected_format="url",
                 )
-            if is_data_url(url_text):
+            if _is_data_url(url_text):
                 image_bytes = _decode_image_base64(url_text)
                 if image_bytes is not None:
                     return _GeneratedImagePayload(

--- a/src/Undefined/webui/static/css/components.css
+++ b/src/Undefined/webui/static/css/components.css
@@ -35,6 +35,8 @@
 .form-group { margin-bottom: 18px; }
 .form-group.is-hidden { display: none; }
 .form-group.is-match { border: 1px solid rgba(217, 119, 87, 0.4); border-radius: var(--radius-sm); padding: 10px; background: rgba(217, 119, 87, 0.05); }
+/* request_params structured editor needs full row width in form-fields grid */
+.form-group.config-request-params { grid-column: 1 / -1; }
 .form-label { display: block; font-size: 12px; font-weight: 500; color: var(--text-secondary); margin-bottom: 8px; text-transform: capitalize; }
 .form-hint { font-size: 12px; color: var(--text-tertiary); margin-bottom: 8px; }
 .form-control { width: 100%; padding: 10px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border-color); background: var(--bg-input); color: var(--text-primary); font-size: 14px; outline: none; }

--- a/src/Undefined/webui/static/js/config-form.js
+++ b/src/Undefined/webui/static/js/config-form.js
@@ -34,9 +34,12 @@ function updateCommentTexts() {
 }
 
 function updateConfigSearchIndex() {
-    document.querySelectorAll(".form-group").forEach((group) => {
-        const label = group.querySelector(".form-label");
-        const hint = group.querySelector(".form-hint");
+    // Only index real config fields (data-path). Nested structural
+    // form-groups inside request_params editors (key/type) must not
+    // participate, or search will hide them independently of the parent.
+    document.querySelectorAll(".form-group[data-path]").forEach((group) => {
+        const label = group.querySelector(":scope > .form-label");
+        const hint = group.querySelector(":scope > .form-hint");
         const path = group.dataset.path || "";
         group.dataset.searchText =
             `${path} ${label ? label.innerText : ""} ${hint ? hint.innerText : ""}`.toLowerCase();
@@ -184,7 +187,10 @@ function applyConfigFilter() {
     let matchCount = 0;
     document.querySelectorAll(".config-card").forEach((card) => {
         let cardMatches = 0;
-        card.querySelectorAll(".form-group").forEach((group) => {
+        // Only filter top-level config fields. Nested form-groups inside
+        // structured editors (request_params key/type) have no data-path
+        // and must stay visible whenever their parent field is shown.
+        card.querySelectorAll(".form-group[data-path]").forEach((group) => {
             const isMatch =
                 !query || (group.dataset.searchText || "").includes(query);
             group.classList.toggle("is-hidden", !isMatch);
@@ -193,7 +199,7 @@ function applyConfigFilter() {
         });
         card.querySelectorAll(".form-subsection").forEach((section) => {
             section.style.display = section.querySelector(
-                ".form-group:not(.is-hidden)",
+                ".form-group[data-path]:not(.is-hidden)",
             )
                 ? ""
                 : "none";
@@ -516,7 +522,7 @@ function inferScalarType(value) {
 
 function createRequestParamsWidget(path, value) {
     const group = document.createElement("div");
-    group.className = "form-group";
+    group.className = "form-group config-request-params";
     group.dataset.path = path;
 
     const label = document.createElement("label");

--- a/tests/test_ai_draw_one_handler.py
+++ b/tests/test_ai_draw_one_handler.py
@@ -24,6 +24,10 @@ _PNG_BYTES = (
     b"\x0b\xe7\x02\x9d"
     b"\x00\x00\x00\x00IEND\xaeB`\x82"
 )
+# 最小魔数夹具，仅用于校验 _decode_image_base64 / _is_likely_image_bytes
+_JPEG_BYTES = b"\xff\xd8\xff\xd9"
+_GIF_BYTES = b"GIF89a" + b"\x00" * 4
+_WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP"
 
 
 def _make_runtime_config(*, request_params: dict[str, Any] | None = None) -> Any:
@@ -310,6 +314,13 @@ def test_decode_image_base64_rejects_non_image_payload() -> None:
 def test_decode_image_base64_accepts_valid_png() -> None:
     payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
     assert ai_draw_handler._decode_image_base64(payload_base64) == _PNG_BYTES
+
+
+def test_decode_image_base64_accepts_jpeg_gif_webp() -> None:
+    """非 PNG 常见格式也应通过魔数校验。"""
+    for image_bytes in (_JPEG_BYTES, _GIF_BYTES, _WEBP_BYTES):
+        payload_base64 = base64.b64encode(image_bytes).decode("ascii")
+        assert ai_draw_handler._decode_image_base64(payload_base64) == image_bytes
 
 
 def test_decode_image_base64_strips_whitespace_in_payload() -> None:

--- a/tests/test_ai_draw_one_handler.py
+++ b/tests/test_ai_draw_one_handler.py
@@ -249,6 +249,127 @@ def test_parse_generated_image_skips_empty_url_and_uses_b64() -> None:
     assert payload.detected_format == "base64"
 
 
+def test_parse_generated_image_broken_data_url_falls_through_to_b64() -> None:
+    """url 中 data URL 解码失败时应继续尝试 b64_json。"""
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    payload = ai_draw_handler._parse_generated_image(
+        {
+            "data": [
+                {
+                    "url": "data:image/png;base64,????",
+                    "b64_json": payload_base64,
+                }
+            ]
+        }
+    )
+    assert payload is not None
+    assert payload.image_bytes == _PNG_BYTES
+    assert payload.detected_format == "b64_json"
+
+
+def test_parse_generated_image_non_url_falls_through_to_sibling_b64() -> None:
+    """非 http(s)/data 的 url 解码失败时，应继续使用同级 b64 字段。"""
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    payload = ai_draw_handler._parse_generated_image(
+        {
+            "data": [
+                {
+                    "url": "not-a-url",
+                    "b64_json": payload_base64,
+                }
+            ]
+        }
+    )
+    assert payload is not None
+    assert payload.image_bytes == _PNG_BYTES
+    assert payload.detected_format == "b64_json"
+
+
+def test_parse_generated_image_raw_base64_in_url_field() -> None:
+    """部分网关把原始 base64 放在 url 字段，应直接解码。"""
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    payload = ai_draw_handler._parse_generated_image(
+        {"data": [{"url": payload_base64}]}
+    )
+    assert payload is not None
+    assert payload.image_url is None
+    assert payload.image_bytes == _PNG_BYTES
+    assert payload.detected_format == "url_base64"
+
+
+def test_decode_image_base64_rejects_invalid_alphabet() -> None:
+    assert ai_draw_handler._decode_image_base64("not!!!valid@@@base64") is None
+
+
+def test_decode_image_base64_rejects_non_image_payload() -> None:
+    """合法 base64 但内容不是图片魔数时返回 None。"""
+    text_payload = base64.b64encode(b"hello world not an image").decode("ascii")
+    assert ai_draw_handler._decode_image_base64(text_payload) is None
+
+
+def test_decode_image_base64_accepts_valid_png() -> None:
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    assert ai_draw_handler._decode_image_base64(payload_base64) == _PNG_BYTES
+
+
+def test_decode_image_base64_strips_whitespace_in_payload() -> None:
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    spaced = "\n".join(
+        payload_base64[i : i + 16] for i in range(0, len(payload_base64), 16)
+    )
+    assert ai_draw_handler._decode_image_base64(spaced) == _PNG_BYTES
+
+
+def test_build_openai_models_edit_form_omits_response_format_when_unset() -> None:
+    form = ai_draw_handler._build_openai_models_edit_form(
+        prompt="edit me",
+        model_name="grok-edit-1.0",
+        size="1024x1024",
+        quality="",
+        style="",
+        response_format="",
+        n=None,
+        extra_params={},
+    )
+    assert "response_format" not in form
+    assert form["prompt"] == "edit me"
+    assert form["model"] == "grok-edit-1.0"
+    assert form["size"] == "1024x1024"
+    assert form["n"] == "1"
+
+
+def test_build_openai_models_edit_form_preserves_request_params_response_format() -> (
+    None
+):
+    form = ai_draw_handler._build_openai_models_edit_form(
+        prompt="edit me",
+        model_name="grok-edit-1.0",
+        size="1024x1024",
+        quality="",
+        style="",
+        response_format="",
+        n=None,
+        extra_params={"response_format": "url", "background": "transparent"},
+    )
+    assert form["response_format"] == "url"
+    assert form["background"] == "transparent"
+
+
+def test_build_openai_models_edit_form_tool_arg_overrides_request_params() -> None:
+    form = ai_draw_handler._build_openai_models_edit_form(
+        prompt="edit me",
+        model_name="grok-edit-1.0",
+        size="1024x1024",
+        quality="",
+        style="",
+        response_format="b64_json",
+        n=2,
+        extra_params={"response_format": "url"},
+    )
+    assert form["response_format"] == "b64_json"
+    assert form["n"] == "2"
+
+
 def test_parse_generated_image_ignores_request_settings_shape() -> None:
     """解析只看 payload，不假设 response_format 设置。"""
     payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
@@ -756,6 +877,59 @@ async def test_execute_models_reference_images_uses_edit_endpoint_and_config(
     assert seen_request["files"][0][0] == "image"
     assert isinstance(seen_request["files"][0][1][1], bytes)
     assert seen_request["files"][0][1][1] == _PNG_BYTES
+
+
+@pytest.mark.asyncio
+async def test_call_openai_models_edit_omits_response_format_and_auto_parses_b64(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """edit 路径：未设 response_format 时不默认塞入；响应按 payload 自动识别。"""
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    reference_path = tmp_path / "reference.png"
+    reference_path.write_bytes(_PNG_BYTES)
+    seen_request: dict[str, Any] = {}
+
+    class _FakeResponse:
+        text = ""
+
+        def json(self) -> dict[str, Any]:
+            # 请求未声明 format，上游仍返回 b64
+            return {"data": [{"b64_json": payload_base64}]}
+
+    async def _fake_request_with_retry(
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> _FakeResponse:
+        seen_request["method"] = method
+        seen_request["url"] = url
+        seen_request["data"] = kwargs.get("data")
+        return _FakeResponse()
+
+    monkeypatch.setattr(ai_draw_handler, "request_with_retry", _fake_request_with_retry)
+
+    result = await ai_draw_handler._call_openai_models_edit(
+        prompt="use this as reference",
+        api_url="https://edit.example.com",
+        api_key="sk-edit",
+        model_name="grok-edit-1.0",
+        size="1024x1024",
+        quality="",
+        style="",
+        response_format="",
+        n=None,
+        timeout_val=30.0,
+        reference_image_paths=[reference_path],
+        extra_params={},
+        context={},
+    )
+
+    assert isinstance(result, ai_draw_handler._GeneratedImagePayload)
+    assert result.image_bytes == _PNG_BYTES
+    assert result.detected_format == "b64_json"
+    assert seen_request["method"] == "POST"
+    assert "response_format" not in (seen_request["data"] or {})
 
 
 @pytest.mark.asyncio

--- a/tests/test_ai_draw_one_handler.py
+++ b/tests/test_ai_draw_one_handler.py
@@ -153,10 +153,11 @@ async def test_execute_models_rejects_invalid_size(
 
 
 @pytest.mark.asyncio
-async def test_execute_models_defaults_response_format_to_base64(
+async def test_execute_models_omits_response_format_when_unset(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """未配置 tool 参数 / request_params 时，请求体不默认带 response_format。"""
     monkeypatch.setattr(
         "Undefined.config.get_config",
         lambda strict=False: _make_runtime_config(request_params={}),
@@ -203,7 +204,245 @@ async def test_execute_models_defaults_response_format_to_base64(
     )
 
     assert result == "AI 绘图已发送给 group 10001"
-    assert seen_request["json_data"]["response_format"] == "base64"
+    assert "response_format" not in seen_request["json_data"]
+    assert seen_request["json_data"]["n"] == 1
+    assert seen_request["json_data"]["prompt"] == "violet flowers"
+    assert seen_request["json_data"]["model"] == "grok-imagine-1.0"
+    assert seen_request["json_data"]["size"] == "1024x1024"
+
+
+def test_parse_generated_image_detects_http_url() -> None:
+    payload = ai_draw_handler._parse_generated_image(
+        {"data": [{"url": "https://cdn.example.com/a.png"}]}
+    )
+    assert payload is not None
+    assert payload.image_url == "https://cdn.example.com/a.png"
+    assert payload.image_bytes is None
+    assert payload.detected_format == "url"
+
+
+def test_parse_generated_image_detects_data_url_in_url_field() -> None:
+    data_url = "data:image/png;base64," + base64.b64encode(_PNG_BYTES).decode("ascii")
+    payload = ai_draw_handler._parse_generated_image({"data": [{"url": data_url}]})
+    assert payload is not None
+    assert payload.image_url is None
+    assert payload.image_bytes == _PNG_BYTES
+    assert payload.detected_format == "data_url"
+
+
+def test_parse_generated_image_decodes_b64_with_data_url_prefix() -> None:
+    data_url = "data:image/png;base64," + base64.b64encode(_PNG_BYTES).decode("ascii")
+    payload = ai_draw_handler._parse_generated_image({"data": [{"b64_json": data_url}]})
+    assert payload is not None
+    assert payload.image_bytes == _PNG_BYTES
+    assert payload.detected_format == "b64_json"
+
+
+def test_parse_generated_image_skips_empty_url_and_uses_b64() -> None:
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    payload = ai_draw_handler._parse_generated_image(
+        {"data": [{"url": "  ", "base64": payload_base64}]}
+    )
+    assert payload is not None
+    assert payload.image_url is None
+    assert payload.image_bytes == _PNG_BYTES
+    assert payload.detected_format == "base64"
+
+
+def test_parse_generated_image_ignores_request_settings_shape() -> None:
+    """解析只看 payload，不假设 response_format 设置。"""
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    as_b64 = ai_draw_handler._parse_generated_image(
+        {"data": [{"b64_json": payload_base64}]}
+    )
+    as_url = ai_draw_handler._parse_generated_image(
+        {"data": [{"url": "https://cdn.example.com/b.png"}]}
+    )
+    assert as_b64 is not None and as_b64.detected_format == "b64_json"
+    assert as_url is not None and as_url.detected_format == "url"
+
+
+@pytest.mark.asyncio
+async def test_execute_models_accepts_b64_when_request_prefers_url(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """请求 response_format=url，上游却返回 b64_json 时仍应成功。"""
+    runtime_config = _make_runtime_config(
+        request_params={"response_format": "url"},
+    )
+    monkeypatch.setattr(
+        "Undefined.config.get_config",
+        lambda strict=False: runtime_config,
+    )
+    monkeypatch.setattr("Undefined.utils.paths.IMAGE_CACHE_DIR", tmp_path)
+
+    payload_base64 = base64.b64encode(_PNG_BYTES).decode("ascii")
+    seen_request: dict[str, Any] = {}
+
+    class _FakeResponse:
+        text = ""
+
+        def json(self) -> dict[str, Any]:
+            return {"data": [{"b64_json": payload_base64}]}
+
+    async def _fake_request_with_retry(
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> _FakeResponse:
+        seen_request["json_data"] = kwargs.get("json_data")
+        return _FakeResponse()
+
+    sent: dict[str, Any] = {}
+
+    async def _send_image(
+        target_id: int | str,
+        message_type: str,
+        file_path: str,
+    ) -> None:
+        sent["file_path"] = file_path
+
+    monkeypatch.setattr(ai_draw_handler, "request_with_retry", _fake_request_with_retry)
+
+    result = await ai_draw_handler.execute(
+        {
+            "prompt": "violet flowers",
+            "size": "1024x1024",
+            "delivery": "send",
+            "target_id": 10001,
+            "message_type": "group",
+        },
+        {"send_image_callback": _send_image},
+    )
+
+    assert result == "AI 绘图已发送给 group 10001"
+    assert seen_request["json_data"]["response_format"] == "url"
+    assert Path(sent["file_path"]).read_bytes() == _PNG_BYTES
+
+
+@pytest.mark.asyncio
+async def test_execute_models_accepts_url_when_request_prefers_b64(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """请求 response_format=b64_json，上游却返回 url 时仍应成功。"""
+    monkeypatch.setattr(
+        "Undefined.config.get_config",
+        lambda strict=False: _make_runtime_config(),
+    )
+    monkeypatch.setattr("Undefined.utils.paths.IMAGE_CACHE_DIR", tmp_path)
+
+    image_url = "https://cdn.example.com/generated.png"
+    seen_request: dict[str, Any] = {}
+    download_urls: list[str] = []
+
+    class _FakeGenResponse:
+        text = ""
+
+        def json(self) -> dict[str, Any]:
+            return {"data": [{"url": image_url}]}
+
+    class _FakeDownloadResponse:
+        content = _PNG_BYTES
+        text = ""
+
+    async def _fake_request_with_retry(
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> Any:
+        if method == "POST":
+            seen_request["json_data"] = kwargs.get("json_data")
+            return _FakeGenResponse()
+        download_urls.append(url)
+        return _FakeDownloadResponse()
+
+    sent: dict[str, Any] = {}
+
+    async def _send_image(
+        target_id: int | str,
+        message_type: str,
+        file_path: str,
+    ) -> None:
+        sent["file_path"] = file_path
+
+    monkeypatch.setattr(ai_draw_handler, "request_with_retry", _fake_request_with_retry)
+
+    result = await ai_draw_handler.execute(
+        {
+            "prompt": "violet flowers",
+            "size": "1024x1024",
+            "response_format": "b64_json",
+            "delivery": "send",
+            "target_id": 10001,
+            "message_type": "group",
+        },
+        {"send_image_callback": _send_image},
+    )
+
+    assert result == "AI 绘图已发送给 group 10001"
+    assert seen_request["json_data"]["response_format"] == "b64_json"
+    assert download_urls == [image_url]
+    assert Path(sent["file_path"]).read_bytes() == _PNG_BYTES
+
+
+@pytest.mark.asyncio
+async def test_execute_models_data_url_response_registers_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """url 字段为 data URL 时应按字节处理，不走远程下载。"""
+    monkeypatch.setattr(
+        "Undefined.config.get_config",
+        lambda strict=False: _make_runtime_config(),
+    )
+    monkeypatch.setattr("Undefined.utils.paths.IMAGE_CACHE_DIR", tmp_path)
+
+    data_url = "data:image/png;base64," + base64.b64encode(_PNG_BYTES).decode("ascii")
+    download_called = False
+
+    class _FakeResponse:
+        text = ""
+
+        def json(self) -> dict[str, Any]:
+            return {"data": [{"url": data_url}]}
+
+    async def _fake_request_with_retry(
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> _FakeResponse:
+        nonlocal download_called
+        if method == "GET":
+            download_called = True
+        return _FakeResponse()
+
+    sent: dict[str, Any] = {}
+
+    async def _send_image(
+        target_id: int | str,
+        message_type: str,
+        file_path: str,
+    ) -> None:
+        sent["file_path"] = file_path
+
+    monkeypatch.setattr(ai_draw_handler, "request_with_retry", _fake_request_with_retry)
+
+    result = await ai_draw_handler.execute(
+        {
+            "prompt": "violet flowers",
+            "size": "1024x1024",
+            "delivery": "send",
+            "target_id": 10001,
+            "message_type": "group",
+        },
+        {"send_image_callback": _send_image},
+    )
+
+    assert result == "AI 绘图已发送给 group 10001"
+    assert download_called is False
+    assert Path(sent["file_path"]).read_bytes() == _PNG_BYTES
 
 
 @pytest.mark.asyncio

--- a/tests/test_webui_config_form_frontend.py
+++ b/tests/test_webui_config_form_frontend.py
@@ -1,0 +1,69 @@
+"""Static frontend contracts for WebUI config form (request_params / search)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Final
+
+from Undefined.utils import io as async_io
+
+CONFIG_FORM_JS: Final[Path] = Path("src/Undefined/webui/static/js/config-form.js")
+COMPONENTS_CSS: Final[Path] = Path("src/Undefined/webui/static/css/components.css")
+
+
+def _read_source(path: Path) -> str:
+    text = asyncio.run(async_io.read_text(path))
+    assert text is not None
+    return text
+
+
+def _has_bare_form_group_query(source: str) -> bool:
+    """True if source still queries all .form-group nodes (not only [data-path])."""
+    return 'querySelectorAll(".form-group")' in source or (
+        'querySelector(\n                ".form-group:not(.is-hidden)",\n            )'
+        in source
+        or '".form-group:not(.is-hidden)"' in source
+    )
+
+
+def test_config_search_filters_only_path_bearing_form_groups() -> None:
+    """Nested key/type form-groups inside request_params must not be filtered alone."""
+    source = _read_source(CONFIG_FORM_JS)
+
+    assert 'querySelectorAll(".form-group[data-path]")' in source
+    assert ".form-group[data-path]:not(.is-hidden)" in source
+    assert not _has_bare_form_group_query(source)
+
+
+def test_config_search_index_only_targets_path_bearing_form_groups() -> None:
+    source = _read_source(CONFIG_FORM_JS)
+    index_fn = source.split("function updateConfigSearchIndex()", 1)[1].split(
+        "function ", 1
+    )[0]
+    assert 'querySelectorAll(".form-group[data-path]")' in index_fn
+    assert 'querySelectorAll(".form-group")' not in index_fn
+
+
+def test_apply_config_filter_only_targets_path_bearing_form_groups() -> None:
+    source = _read_source(CONFIG_FORM_JS)
+    filter_fn = source.split("function applyConfigFilter()", 1)[1].split(
+        "function ", 1
+    )[0]
+    assert 'querySelectorAll(".form-group[data-path]")' in filter_fn
+    assert ".form-group[data-path]:not(.is-hidden)" in filter_fn
+    assert 'querySelectorAll(".form-group")' not in filter_fn
+    assert '".form-group:not(.is-hidden)"' not in filter_fn
+
+
+def test_request_params_widget_contracts() -> None:
+    source = _read_source(CONFIG_FORM_JS)
+    css = _read_source(COMPONENTS_CSS)
+
+    assert "function isRequestParamsPath(path)" in source
+    assert 'path.endsWith(".request_params")' in source
+    assert "function createRequestParamsWidget(path, value)" in source
+    assert 'editor.dataset.requestParamsRoot = "true"' in source
+    assert "config-request-params" in source
+    assert ".form-group.config-request-params" in css
+    assert "grid-column: 1 / -1" in css

--- a/tests/test_webui_config_form_frontend.py
+++ b/tests/test_webui_config_form_frontend.py
@@ -1,10 +1,15 @@
-"""Static frontend contracts for WebUI config form (request_params / search)."""
+"""Static + behavioral frontend contracts for WebUI config form (request_params / search)."""
 
 from __future__ import annotations
 
 import asyncio
+import json
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Final
+
+import pytest
 
 from Undefined.utils import io as async_io
 
@@ -67,3 +72,223 @@ def test_request_params_widget_contracts() -> None:
     assert "config-request-params" in source
     assert ".form-group.config-request-params" in css
     assert "grid-column: 1 / -1" in css
+
+
+def test_request_params_nested_key_type_editors_lack_data_path() -> None:
+    """key/type structural editors must not get data-path (or search will hide them)."""
+    source = _read_source(CONFIG_FORM_JS)
+
+    key_entry = source.split("function createStructuredObjectEntry", 1)[1].split(
+        "function ", 1
+    )[0]
+    assert 'keyGroup.className = "form-group"' in key_entry
+    assert "keyGroup.dataset.path" not in key_entry
+    assert "keyGroup.dataset.searchText" not in key_entry
+
+    scalar = source.split("function createStructuredScalarEditor", 1)[1].split(
+        "function ", 1
+    )[0]
+    assert 'typeGroup.className = "form-group"' in scalar
+    assert "typeGroup.dataset.path" not in scalar
+    assert "typeGroup.dataset.searchText" not in scalar
+
+    widget = source.split("function createRequestParamsWidget", 1)[1].split(
+        "function ", 1
+    )[0]
+    assert "group.dataset.path = path" in widget
+
+
+def test_apply_config_filter_behavior_keeps_nested_request_params_visible() -> None:
+    """Mini-DOM behavioral check: parent match keeps nested key/type form-groups visible.
+
+    Replicates applyConfigFilter's selection rule (only .form-group[data-path])
+    against a request_params-shaped tree without pulling in jsdom.
+    """
+    if shutil.which("node") is None:
+        pytest.skip("node is required for mini-DOM config filter behavior test")
+
+    script = r"""
+class TokenList {
+  constructor(el) { this.el = el; this._set = new Set(); }
+  add(c) { this._set.add(c); }
+  remove(c) { this._set.delete(c); }
+  contains(c) { return this._set.has(c); }
+  toggle(c, force) {
+    if (force === undefined) {
+      if (this._set.has(c)) { this._set.delete(c); return false; }
+      this._set.add(c); return true;
+    }
+    if (force) { this._set.add(c); return true; }
+    this._set.delete(c); return false;
+  }
+  toArray() { return [...this._set]; }
+}
+
+function matchesSelector(el, selector) {
+  if (selector === ".config-card") {
+    return el.classList.contains("config-card");
+  }
+  if (selector === ".form-subsection") {
+    return el.classList.contains("form-subsection");
+  }
+  if (selector === ".form-group[data-path]") {
+    return el.classList.contains("form-group") && el.dataset.path != null && el.dataset.path !== "";
+  }
+  if (selector === ".form-group[data-path]:not(.is-hidden)") {
+    return (
+      el.classList.contains("form-group") &&
+      el.dataset.path != null &&
+      el.dataset.path !== "" &&
+      !el.classList.contains("is-hidden")
+    );
+  }
+  return false;
+}
+
+function walk(root, selector, out) {
+  if (matchesSelector(root, selector)) out.push(root);
+  for (const child of root.children || []) walk(child, selector, out);
+  return out;
+}
+
+function createEl(tag, className, dataset = {}) {
+  const el = {
+    tagName: tag.toUpperCase(),
+    classList: null,
+    dataset: { ...dataset },
+    children: [],
+    parent: null,
+    style: {},
+    querySelectorAll(sel) {
+      const out = [];
+      for (const child of this.children) walk(child, sel, out);
+      return out;
+    },
+    querySelector(sel) {
+      return this.querySelectorAll(sel)[0] || null;
+    },
+  };
+  el.classList = new TokenList(el);
+  // bridge TokenList <-> string className for contains checks
+  const originalAdd = el.classList.add.bind(el.classList);
+  const originalRemove = el.classList.remove.bind(el.classList);
+  const originalToggle = el.classList.toggle.bind(el.classList);
+  el.classList.add = (...args) => {
+    for (const c of args) {
+      originalAdd(c);
+      el._className = (el._className || "") + " " + c;
+    }
+  };
+  el.classList.remove = (...args) => {
+    for (const c of args) {
+      originalRemove(c);
+    }
+  };
+  el.classList.toggle = (c, force) => {
+    const result = originalToggle(c, force);
+    return result;
+  };
+  el.classList.contains = (c) => el.classList._set.has(c);
+  if (className) {
+    for (const c of className.split(/\s+/).filter(Boolean)) el.classList.add(c);
+  }
+  return el;
+}
+
+function append(parent, child) {
+  child.parent = parent;
+  parent.children.push(child);
+  return child;
+}
+
+// Build: card > parent request_params form-group[data-path] > nested key/type form-groups
+const card = createEl("div", "config-card");
+const parent = createEl("div", "form-group config-request-params", {
+  path: "models.image_gen.request_params",
+  searchText: "models.image_gen.request_params response_format",
+});
+const keyGroup = createEl("div", "form-group"); // no data-path
+const typeGroup = createEl("div", "form-group"); // no data-path
+append(parent, keyGroup);
+append(parent, typeGroup);
+append(card, parent);
+
+const other = createEl("div", "form-group", {
+  path: "models.image_gen.api_url",
+  searchText: "models.image_gen.api_url api url",
+});
+append(card, other);
+
+const document = {
+  querySelectorAll(sel) {
+    if (sel === ".config-card") return [card];
+    return [];
+  },
+};
+
+// Mirror applyConfigFilter selection rules from config-form.js
+function applyConfigFilter(query) {
+  document.querySelectorAll(".config-card").forEach((cardEl) => {
+    let cardMatches = 0;
+    cardEl.querySelectorAll(".form-group[data-path]").forEach((group) => {
+      const isMatch = !query || (group.dataset.searchText || "").includes(query);
+      group.classList.toggle("is-hidden", !isMatch);
+      group.classList.toggle("is-match", isMatch && query.length > 0);
+      if (isMatch) cardMatches += 1;
+    });
+    cardEl.classList.toggle("is-hidden", query.length > 0 && cardMatches === 0);
+  });
+}
+
+applyConfigFilter("request_params");
+
+const result = {
+  parentHidden: parent.classList.contains("is-hidden"),
+  parentMatch: parent.classList.contains("is-match"),
+  keyHidden: keyGroup.classList.contains("is-hidden"),
+  typeHidden: typeGroup.classList.contains("is-hidden"),
+  otherHidden: other.classList.contains("is-hidden"),
+  pathBearingCount: card.querySelectorAll(".form-group[data-path]").length,
+  allFormGroupCount: (() => {
+    const out = [];
+    function countAll(el) {
+      if (el.classList && el.classList.contains("form-group")) out.push(el);
+      for (const c of el.children || []) countAll(c);
+    }
+    countAll(card);
+    return out.length;
+  })(),
+};
+
+if (result.parentHidden) throw new Error("parent request_params should be visible on match");
+if (!result.parentMatch) throw new Error("parent should be marked is-match");
+if (result.keyHidden) throw new Error("nested key form-group must not be auto-hidden");
+if (result.typeHidden) throw new Error("nested type form-group must not be auto-hidden");
+if (!result.otherHidden) throw new Error("non-matching field should be hidden");
+if (result.pathBearingCount !== 2) throw new Error("expected 2 path-bearing form-groups");
+if (result.allFormGroupCount !== 4) throw new Error("expected 4 total form-groups in tree");
+
+// Empty query shows everything
+applyConfigFilter("");
+if (parent.classList.contains("is-hidden")) throw new Error("empty query: parent hidden");
+if (other.classList.contains("is-hidden")) throw new Error("empty query: other hidden");
+if (keyGroup.classList.contains("is-hidden")) throw new Error("empty query: key hidden");
+
+console.log(JSON.stringify({ ok: true, ...result }));
+"""
+    completed = subprocess.run(
+        ["node", "-e", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert completed.returncode == 0, (
+        f"mini-DOM filter test failed:\nstdout={completed.stdout}\nstderr={completed.stderr}"
+    )
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert payload["ok"] is True
+    assert payload["keyHidden"] is False
+    assert payload["typeHidden"] is False
+    assert payload["parentHidden"] is False
+    assert payload["otherHidden"] is True

--- a/tests/test_webui_config_form_frontend.py
+++ b/tests/test_webui_config_form_frontend.py
@@ -25,9 +25,8 @@ def _read_source(path: Path) -> str:
 
 def _has_bare_form_group_query(source: str) -> bool:
     """True if source still queries all .form-group nodes (not only [data-path])."""
-    return 'querySelectorAll(".form-group")' in source or (
-        'querySelector(\n                ".form-group:not(.is-hidden)",\n            )'
-        in source
+    return (
+        'querySelectorAll(".form-group")' in source
         or '".form-group:not(.is-hidden)"' in source
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -4626,7 +4626,7 @@ wheels = [
 
 [[package]]
 name = "undefined-bot"
-version = "3.6.7"
+version = "3.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **生图链路**：OpenAI 兼容生图不再错误默认 `response_format=base64`，改为按实际 payload 自动识别 `http(s) url` / data URL / raw base64 / `b64_json` / `base64`；仅在工具参数显式传入时覆盖 `response_format`，否则保留 `request_params`。
- **解码加固**：base64 使用 `validate=True` 校验字母表，并用 PNG/JPEG/GIF/BMP/WEBP 魔数确认结果为图片，拒绝把错误文本当成功生图。
- **WebUI 配置搜索**：索引与过滤仅针对带 `data-path` 的表单项，`request_params` 结构化编辑器内的 key/type 控件在搜索匹配时不再被单独隐藏，编辑器占满网格宽度。
- **版本与文档**：同步 3.6.8 版本号（Python / Console / Chat / Tauri / lock）与 CHANGELOG、配置文档及回归测试。

## Test plan

- [x] `uv run ruff format --check .` / `ruff check` / `mypy`（pre-commit）
- [ ] `uv run pytest tests/test_ai_draw_one_handler.py tests/test_webui_config_form_frontend.py -v`
- [ ] 手动验证：不配 `response_format` 时生图成功；返回 url / b64_json / raw base64 均可解析
- [ ] 手动验证：WebUI 配置搜索 `request_params` 时 key/type 控件仍可见

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of image-generation/edit responses (handles URL, data URL, and base64 variants more reliably).
  * Added stricter base64 validation with image signature checks to avoid treating non-image text as images.
  * WebUI config search/filtering now correctly shows nested request-parameter controls and prevents hidden indexing conflicts.

* **Documentation**
  * Updated configuration docs and changelog to reflect the new image response parsing behavior.

* **Chores**
  * Bumped versions to **3.6.8** across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->