### PR TITLE
docs: add remote search MCP config example

### DIFF
--- a/config/mcp.json.example
+++ b/config/mcp.json.example
@@ -7,6 +7,10 @@
         "howtocook-mcp": {
             "command": "npx",
             "args": ["-y", "howtocook-mcp"]
+        },
+        "parallel-search": {
+            "url": "https://search.parallel.ai/mcp",
+            "transport": "http"
         }
     }
 }


### PR DESCRIPTION
Undefined's starter MCP config currently shows only local process servers, even though its FastMCP registry also supports remote HTTP servers. This adds a copyable remote search example through the same existing configuration path.

## What changed

- Added a `parallel-search` entry using the existing remote HTTP MCP format.
- Kept the current servers, runtime behavior, dependencies, and defaults unchanged.
- The endpoint does not require an account, API key, or OAuth setup.

## Validation

- `python3 -m json.tool config/mcp.json.example`
- Exact JSON assertion for the preserved server order and new record
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `parallel-search` to the example MCP configuration.
  * Configured it to use Parallel’s HTTP MCP endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->